### PR TITLE
User mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### ♝ Code Requirements
 * [ ] Set up packages for methods.
-* [ ] The controller of the program needs to be able to instert into database,
+* [ ] The controller of the program needs to be able to insert into database,
 * [ ] Method to delete entries by id
 * [ ] Method to update them by id
 * [ ] Method to read all

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+
+# ♜ ELOmatch ♟️
+
+### ♝ Code Requirements
+* [ ] Set up packages for methods.
+* [ ] The controller of the program needs to be able to instert into database,
+* [ ] Method to delete entries by id
+* [ ] Method to update them by id
+* [ ] Method to read all
+* [ ] Method to read by id.
+* [ ] Code must use MVC, object orientation
+* [ ] Code must have appropriate unit testing - test all CRUD operations.

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>3.1.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/com/wileyedge/elomatch/entity/User.java
+++ b/src/main/java/com/wileyedge/elomatch/entity/User.java
@@ -52,7 +52,8 @@ public class User {
     @Column(name = "elo")
     private Long elo;
     @Column(name = "is_toxic", columnDefinition = "BIT(1)")
-    private Boolean isToxic;
+    private Boolean isToxic; // We can now use a BIT column to store one or many true/false values in a single column.
+    // BIT(1) defines a field that contains a single bit.
 
     // We have included a ManyToOne relationship with the Experience entity,
     // specifying that multiple users can be associated with a single experience.

--- a/src/main/java/com/wileyedge/elomatch/model/CreateOrModifyUserModel.java
+++ b/src/main/java/com/wileyedge/elomatch/model/CreateOrModifyUserModel.java
@@ -14,10 +14,11 @@ public class CreateOrModifyUserModel {
     // you only need the playerName and UserName to modify the user
     // you wouldn't allow the user to change rank or change the istoxic player otherwise
     // they could cheat.
-    // they can also create there own user identity to start a match
+    // they can also create their own user identity to start a match
     // which will identify them as beginner status.
     private String playerName;
     private String userName;
+    // For now, I have added elo and isToxic for insert data.
     private Long elo;
     private Boolean isToxic;
 }

--- a/src/main/java/com/wileyedge/elomatch/model/CreateOrModifyUserModel.java
+++ b/src/main/java/com/wileyedge/elomatch/model/CreateOrModifyUserModel.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateOrModifyUser {
+public class CreateOrModifyUserModel {
 
     // you only need the playerName and UserName to modify the user
     // you wouldn't allow the user to change rank or change the istoxic player otherwise

--- a/src/main/java/com/wileyedge/elomatch/model/CreateOrModifyUserModel.java
+++ b/src/main/java/com/wileyedge/elomatch/model/CreateOrModifyUserModel.java
@@ -18,4 +18,6 @@ public class CreateOrModifyUser {
     // which will identify them as beginner status.
     private String playerName;
     private String userName;
+    private Long elo;
+    private Boolean isToxic;
 }

--- a/src/main/java/com/wileyedge/elomatch/model/UserModel.java
+++ b/src/main/java/com/wileyedge/elomatch/model/UserModel.java
@@ -1,0 +1,2 @@
+package com.wileyedge.elomatch.model;public class UserModel {
+}

--- a/src/main/java/com/wileyedge/elomatch/model/UserModel.java
+++ b/src/main/java/com/wileyedge/elomatch/model/UserModel.java
@@ -1,2 +1,16 @@
-package com.wileyedge.elomatch.model;public class UserModel {
+package com.wileyedge.elomatch.model;
+
+public class UserModel {
+
+
+    private Long id;
+
+    private String playerName;
+
+    private String userName;
+
+    private Long elo;
+
+    private Boolean isToxic;
+
 }

--- a/src/main/java/com/wileyedge/elomatch/service/UserService.java
+++ b/src/main/java/com/wileyedge/elomatch/service/UserService.java
@@ -1,8 +1,10 @@
 package com.wileyedge.elomatch.service;
 
 import com.wileyedge.elomatch.entity.User;
-import com.wileyedge.elomatch.model.CreateOrModifyUser;
+import com.wileyedge.elomatch.model.CreateOrModifyUserModel;
+import com.wileyedge.elomatch.model.UserModel;
 import com.wileyedge.elomatch.persistence.UserRepository;
+import com.wileyedge.elomatch.util.Mapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -41,25 +43,29 @@ public class UserService {
         return userRepository.findByUserName(userName);
     }
    // try to keep delete as void or if you want to keep back anything then keep as boolean
+
     public String deleteUser(Long id){
        userRepository.deleteById(id);
        return "User removed " + id;
     }
 
-    public User updateUser(Long id, CreateOrModifyUser createOrModifyUser) {
+    public UserModel updateUser(Long id, CreateOrModifyUserModel createOrModifyUserModel) {
         // existing user id which comes from the database from particular id search
         // and then that will be the existing whole user. with all fields, and original.
         User existingUser = userRepository.findById(id).orElse(null);
         // .1 found
         // .2 set modification fields inside
-        Objects.requireNonNull(existingUser).setUserName(createOrModifyUser.getUserName());
-        existingUser.setPlayerName(createOrModifyUser.getPlayerName());
+        Objects.requireNonNull(existingUser).setUserName(createOrModifyUserModel.getUserName());
+        existingUser.setPlayerName(createOrModifyUserModel.getPlayerName());
+        existingUser.setElo(createOrModifyUserModel.getElo());
+        existingUser.setIsToxic(createOrModifyUserModel.getIsToxic());
 //        existingUser.setUserName(user.getUserName());
 //        existingUser.setPlayerName(user.getPlayerName());
 //        existingUser.setElo(user.getElo());
         // existingUser. need to figure out isToxic, not appearing as get method.
-        return userRepository.save(existingUser);
+        return Mapper.mapUserEntityToModel(userRepository.save(existingUser));
     }
+
 
 //    public UserModel updateUser(UserModel user) {
 //        UserModel existingUser = userRepository.findById(user.getUser_id()).orElse(null);

--- a/src/main/java/com/wileyedge/elomatch/util/Mapper.java
+++ b/src/main/java/com/wileyedge/elomatch/util/Mapper.java
@@ -1,0 +1,29 @@
+package com.wileyedge.elomatch.util;
+
+import com.wileyedge.elomatch.entity.User;
+import com.wileyedge.elomatch.model.CreateOrModifyUserModel;
+import org.modelmapper.ModelMapper;
+
+public class UserMapper {
+
+    // placing all static mapper methods in this class.
+    private static final ModelMapper modelMapper = new ModelMapper();
+
+//    public static User mapCreateOrModifyUserToUserEntity(CreateOrModifyUser createOrModifyUser){
+//        User user = new User();
+//        user.setPlayerName(createOrModifyUser.getPlayerName());
+//        user.setUserName(createOrModifyUser.getUserName());
+//        user.setElo(createOrModifyUser.getElo());
+//        user.setIsToxic(createOrModifyUser.getIsToxic());
+//        return user;
+//    }
+
+    public static User mapUserEntityToModel(CreateOrModifyUserModel model){
+        return modelMapper.map(model, User.class);
+    }
+    private UserMapper(){
+
+    }
+
+
+}

--- a/src/main/java/com/wileyedge/elomatch/util/Mapper.java
+++ b/src/main/java/com/wileyedge/elomatch/util/Mapper.java
@@ -2,9 +2,10 @@ package com.wileyedge.elomatch.util;
 
 import com.wileyedge.elomatch.entity.User;
 import com.wileyedge.elomatch.model.CreateOrModifyUserModel;
+import com.wileyedge.elomatch.model.UserModel;
 import org.modelmapper.ModelMapper;
 
-public class UserMapper {
+public class Mapper {
 
     // placing all static mapper methods in this class.
     private static final ModelMapper modelMapper = new ModelMapper();
@@ -21,9 +22,14 @@ public class UserMapper {
     public static User mapUserEntityToModel(CreateOrModifyUserModel model){
         return modelMapper.map(model, User.class);
     }
-    private UserMapper(){
 
+
+    public static UserModel mapUserEntityToModel(User user){
+        return modelMapper.map(user, UserModel.class);
     }
 
+    private Mapper(){
+
+    }
 
 }

--- a/src/main/java/com/wileyedge/elomatch/util/Mapper.java
+++ b/src/main/java/com/wileyedge/elomatch/util/Mapper.java
@@ -8,7 +8,14 @@ import org.modelmapper.ModelMapper;
 public class Mapper {
 
     // placing all static mapper methods in this class.
+    // Create a ModelMapper object for mapping entities to models.
     private static final ModelMapper modelMapper = new ModelMapper();
+
+
+    // Setting the User object properties based on the CreateOrModifyUserModel properties.
+    // This was my first interpretation of the mapper created before.
+    // It creates a new object.
+    // Then Returns the User entity object.
 
 //    public static User mapCreateOrModifyUserToUserEntity(CreateOrModifyUser createOrModifyUser){
 //        User user = new User();
@@ -19,17 +26,21 @@ public class Mapper {
 //        return user;
 //    }
 
+    // Map a CreateOrModifyUserModel object to a User entity.
+    // Create a new User object.
     public static User mapUserEntityToModel(CreateOrModifyUserModel model){
         return modelMapper.map(model, User.class);
     }
 
-
+    // Map a User entity to a UserModel object.
+    // Use the modelMapper object to map the properties from User to UserModel
     public static UserModel mapUserEntityToModel(User user){
         return modelMapper.map(user, UserModel.class);
     }
 
+    // Private constructor to prevent instantiation of the Mapper class
     private Mapper(){
-
+        // This constructor is empty as it's meant to prevent the instantiation of the Mapper class.
     }
 
 }

--- a/src/main/java/com/wileyedge/elomatch/util/UserMapper.java
+++ b/src/main/java/com/wileyedge/elomatch/util/UserMapper.java
@@ -1,0 +1,4 @@
+package com.wileyedge.elomatch.util;
+
+public class UserMapper {
+}

--- a/src/main/java/com/wileyedge/elomatch/util/UserMapper.java
+++ b/src/main/java/com/wileyedge/elomatch/util/UserMapper.java
@@ -1,4 +1,0 @@
-package com.wileyedge.elomatch.util;
-
-public class UserMapper {
-}


### PR DESCRIPTION
- added and installed ModelMapper Maven Dependancy, ran and installed it.

- Created class of Mapper.

- Created a ModelMapper object for mapping entities to models.

- first interpretation of the mapper which sets user properties and is based on creating and modifying user.

- Final solution of Mapping  a User entity to a UserModel object with the use of modelMapper object to map the properties from User to UserModel.

- public static UserModel mapUserEntityToModel(User user): This line defines a static method called mapUserEntityToModel, which takes a User object as input and returns a UserModel object.

- return modelMapper.map(user, UserModel.class);: This line uses a modelMapper object to map the properties of the User object to the corresponding properties of a UserModel object. The modelMapper seems to be an instance of a library or framework used for object mapping or conversion.

- Private constructor to prevent instantiation of the Mapper class.

- Also updated UserService.

- created class of UserModel.

- updated README.md with title for ELOmatch.

- Tick box markdown for code requirements.